### PR TITLE
Add local GGUF chat server with disk memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore Python cache and compiled files
+__pycache__/
+*.pyc
+
+# Ignore model weights and local memory
+*.gguf
+memory/
+
+# Local configuration overrides
+config/local.yaml

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,2 @@
+model_path: /path/to/model.gguf
+memory_dir: memory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pyyaml
+llama-cpp-python
+httpx

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -1,0 +1,11 @@
+"""Script to launch the chat server."""
+from __future__ import annotations
+
+import uvicorn
+
+from chat_server.server import create_app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/chat_server/__init__.py
+++ b/src/chat_server/__init__.py
@@ -1,0 +1,1 @@
+"""Chat server package for running a local GGUF model with disk memory."""

--- a/src/chat_server/config.py
+++ b/src/chat_server/config.py
@@ -1,0 +1,23 @@
+"""Configuration loading for the chat server."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Load YAML configuration for the chat server.
+
+    Parameters
+    ----------
+    path: str | None
+        Optional path to a configuration file. If not provided, the
+        environment variable ``CHAT_SERVER_CONFIG`` is consulted. As a
+        last resort ``config/default.yaml`` is used.
+    """
+    if path is None:
+        path = os.environ.get("CHAT_SERVER_CONFIG", "config/default.yaml")
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)

--- a/src/chat_server/llm.py
+++ b/src/chat_server/llm.py
@@ -1,0 +1,19 @@
+"""Wrapper for loading a GGUF model via llama.cpp."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class GGUFModel:
+    """Thin wrapper around :mod:`llama_cpp` to generate text."""
+
+    def __init__(self, model_path: str, **kwargs: Any) -> None:
+        # Import here so tests can run without the dependency installed.
+        from llama_cpp import Llama  # type: ignore
+
+        self.llama = Llama(model_path=model_path, **kwargs)
+
+    def generate(self, prompt: str, max_tokens: int = 128) -> str:
+        """Generate text given a prompt."""
+        output = self.llama(prompt, max_tokens=max_tokens)
+        return output["choices"][0]["text"]

--- a/src/chat_server/memory.py
+++ b/src/chat_server/memory.py
@@ -1,0 +1,35 @@
+"""Disk-based conversation memory keyed by identity."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+
+class DiskMemory:
+    """Simple JSON-based memory storage on disk.
+
+    Conversations are stored per identity in ``memory_dir``. Each file
+    contains a list of message dictionaries with ``user`` and
+    ``assistant`` fields.
+    """
+
+    def __init__(self, memory_dir: str) -> None:
+        self.memory_dir = memory_dir
+        os.makedirs(self.memory_dir, exist_ok=True)
+
+    def _path(self, identity: str) -> str:
+        return os.path.join(self.memory_dir, f"{identity}.json")
+
+    def load(self, identity: str) -> List[Dict[str, Any]]:
+        path = self._path(identity)
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return []
+
+    def append(self, identity: str, message: Dict[str, Any]) -> None:
+        history = self.load(identity)
+        history.append(message)
+        with open(self._path(identity), "w", encoding="utf-8") as f:
+            json.dump(history, f, ensure_ascii=False, indent=2)

--- a/src/chat_server/server.py
+++ b/src/chat_server/server.py
@@ -1,0 +1,50 @@
+"""FastAPI application wrapping a local LLM with disk memory."""
+from __future__ import annotations
+
+from typing import List, Dict, Any, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .config import load_config
+from .llm import GGUFModel
+from .memory import DiskMemory
+
+
+class ChatRequest(BaseModel):
+    identity: str
+    message: str
+
+
+def build_prompt(history: List[Dict[str, Any]], message: str) -> str:
+    lines = []
+    for item in history:
+        lines.append(f"User: {item['user']}")
+        lines.append(f"Assistant: {item['assistant']}")
+    lines.append(f"User: {message}")
+    lines.append("Assistant:")
+    return "\n".join(lines)
+
+
+def create_app(
+    config_path: Optional[str] = None,
+    model: Optional[Any] = None,
+    memory: Optional[DiskMemory] = None,
+) -> FastAPI:
+    config = load_config(config_path) if (config_path or model is None or memory is None) else {}
+    if model is None:
+        model = GGUFModel(config["model_path"])
+    if memory is None:
+        memory = DiskMemory(config.get("memory_dir", "memory"))
+
+    app = FastAPI()
+
+    @app.post("/chat")
+    def chat(req: ChatRequest) -> Dict[str, str]:
+        history = memory.load(req.identity)
+        prompt = build_prompt(history, req.message)
+        response = model.generate(prompt)
+        memory.append(req.identity, {"user": req.message, "assistant": response})
+        return {"response": response}
+
+    return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the import path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from chat_server.memory import DiskMemory
+
+
+def test_disk_memory_roundtrip(tmp_path):
+    memory = DiskMemory(str(tmp_path))
+    identity = "user123"
+    message = {"user": "hi", "assistant": "hello"}
+    memory.append(identity, message)
+    assert memory.load(identity) == [message]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from chat_server.server import create_app
+from chat_server.memory import DiskMemory
+
+
+class DummyModel:
+    def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
+        return "ok"
+
+
+def test_chat_endpoint(tmp_path):
+    memory = DiskMemory(str(tmp_path))
+    app = create_app(model=DummyModel(), memory=memory)
+    client = TestClient(app)
+    r = client.post("/chat", json={"identity": "u1", "message": "Hello"})
+    assert r.status_code == 200
+    assert r.json()["response"] == "ok"
+    assert memory.load("u1") == [{"user": "Hello", "assistant": "ok"}]


### PR DESCRIPTION
## Summary
- implement FastAPI chat server that runs a GGUF model and stores history per identity
- persist conversation state using JSON files on disk
- provide script, configuration, and tests for memory and API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b758ab1edc8321a8c575d7d7da38df