### PR TITLE
Add test for identity anchors

### DIFF
--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,6 @@
+def test_anchors_present():
+    import yaml
+    with open("src/identity/anchors.yaml", "r", encoding="utf-8") as f:
+        anchors = yaml.safe_load(f)
+    assert anchors.get("system_name") == "Ember"
+    assert len(anchors.get("anchors", [])) >= 3


### PR DESCRIPTION
## Summary
- add test verifying identity anchors configuration includes system name Ember and at least three anchors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b765ca4c088321a7d6e7626b24005e