### PR TITLE
Add basic web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Local LLM server with memory and identity anchors. Plus a tiny Transformer demo 
 7. Test:
    curl -s http://localhost:8000/health
    curl -s http://localhost:8000/chat -H "Content-Type: application/json" -d '{"message":"Say hi in one sentence"}'
+8. Open http://localhost:8000/ in a browser for a simple web chat interface
 
 Customize identity in src/identity/anchors.yaml
 

--- a/index/index.html
+++ b/index/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ember Chat</title>
+  <link rel="stylesheet" href="/assets/style.css" />
+</head>
+<body>
+  <div id="chat-container">
+    <h1>Ember Chat</h1>
+    <div id="chat-box"></div>
+    <input id="message" type="text" placeholder="Type a message" />
+    <button id="send">Send</button>
+  </div>
+  <script src="/assets/main.js"></script>
+</body>
+</html>

--- a/index/main.js
+++ b/index/main.js
@@ -1,0 +1,24 @@
+async function sendMessage() {
+  const input = document.getElementById('message');
+  const msg = input.value.trim();
+  if (!msg) return;
+  const res = await fetch('/chat', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({message: msg}),
+  });
+  const data = await res.json();
+  const box = document.getElementById('chat-box');
+  box.innerHTML += `<div class="user">${msg}</div>`;
+  box.innerHTML += `<div class="assistant">${data.reply}</div>`;
+  input.value = '';
+  box.scrollTop = box.scrollHeight;
+}
+
+document.getElementById('send').addEventListener('click', sendMessage);
+
+document.getElementById('message').addEventListener('keypress', (e) => {
+  if (e.key === 'Enter') {
+    sendMessage();
+  }
+});

--- a/index/style.css
+++ b/index/style.css
@@ -1,0 +1,33 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+}
+#chat-container {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+#chat-box {
+  height: 300px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+.user {
+  text-align: right;
+  color: #333;
+}
+.assistant {
+  text-align: left;
+  color: #0066cc;
+}
+#message {
+  width: calc(100% - 60px);
+}
+#send {
+  width: 50px;
+}

--- a/src/app.py
+++ b/src/app.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 import yaml
 from .llm.engine import LLMEngine
 from .memory.store import MemoryStore
 
 app = FastAPI(title="Ember Local Server")
+app.mount("/assets", StaticFiles(directory="index"), name="assets")
 
 with open("config.yaml", "r", encoding="utf-8") as f:
     CFG = yaml.safe_load(f)
@@ -50,3 +53,8 @@ async def chat(inp: ChatIn):
     MEM.add("assistant", reply)
 
     return {"reply": reply}
+
+
+@app.get("/")
+async def root():
+    return FileResponse("index/index.html")


### PR DESCRIPTION
## Summary
- serve static `index` folder with FastAPI
- provide simple HTML/JS chat client
- document web UI usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b769f527c88321b23e78e58e8b55a3