### PR TITLE
Add full web search + fetch tools to local LLM server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Local LLM server with memory and identity anchors. Plus a tiny Transformer demo 
 
 Customize identity in src/identity/anchors.yaml
 
+### Internet search in chat
+curl -s http://127.0.0.1:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"What is new at Gobekli Tepe?", "use_web": true}'
+
+### Fetch specific URLs
+curl -s http://127.0.0.1:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Summarize these pages", "urls":["https://example.com/a","https://example.com/b"]}'
+
+### Direct search/fetch
+curl -s "http://127.0.0.1:8000/search?q=thorium%20reactors"
+curl -s "http://127.0.0.1:8000/fetch?url=https://arxiv.org/abs/2407.12345"
+
 ## Mode 2 — Tiny trainer
 Your original model.py stays. Run: python model.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ faiss-cpu==1.8.0.post1
 sentence-transformers==3.0.1
 llama-cpp-python==0.3.2
 tenacity==9.0.0
+
+httpx==0.27.0
+duckduckgo-search==6.2.10
+trafilatura==1.12.2
+readability-lxml==0.8.1

--- a/src/app.py
+++ b/src/app.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import yaml
 from .llm.engine import LLMEngine
 from .memory.store import MemoryStore
+from .tools.web import web_search, fetch_url
 
 app = FastAPI(title="Ember Local Server")
 app.mount("/assets", StaticFiles(directory="index"), name="assets")
@@ -22,6 +23,9 @@ with open(CFG["identity"]["anchors_file"], "r", encoding="utf-8") as f:
 
 class ChatIn(BaseModel):
     message: str
+    use_web: bool = Field(default=False)
+    web_query: str | None = None
+    urls: list[str] | None = None
 
 
 @app.get("/health")
@@ -32,6 +36,30 @@ async def health():
 @app.post("/chat")
 async def chat(inp: ChatIn):
     query = inp.message.strip()
+
+    web_lines = []
+    if inp.use_web:
+        q = (inp.web_query or inp.message).strip()
+        hits = web_search(q, max_results=6)
+        if hits:
+            web_lines.append("Web search results:")
+            for i, h in enumerate(hits, 1):
+                web_lines.append(f"[{i}] {h['title']} — {h['url']}")
+                if h["snippet"]:
+                    web_lines.append(f"    {h['snippet']}")
+    if inp.urls:
+        web_lines.append("Fetched pages:")
+        for u in inp.urls:
+            try:
+                page = fetch_url(u)
+                title = page.get("title") or page["url"]
+                preview = (page.get("text") or "")[:5000]
+                web_lines.append(f"- {title} — {page['url']}")
+                if preview:
+                    web_lines.append(preview)
+            except Exception as e:
+                web_lines.append(f"- Error fetching {u}: {e}")
+
     k = int(CFG["memory"]["max_context_snippets"])
     snippets = MEM.search(query, k=k)
 
@@ -41,6 +69,9 @@ async def chat(inp: ChatIn):
     ]
     for a in ANCH.get("anchors", []):
         sys_lines.append(a)
+    if web_lines:
+        sys_lines.append("\n".join(web_lines))
+        sys_lines.append("Use these sources and cite [numbers] or URLs in your answer.")
     if snippets:
         sys_lines.append("Relevant memory:")
         for m in snippets:
@@ -58,3 +89,16 @@ async def chat(inp: ChatIn):
 @app.get("/")
 async def root():
     return FileResponse("index/index.html")
+
+
+from fastapi import Query as FQuery
+
+
+@app.get("/search")
+async def search_api(q: str = FQuery(..., min_length=2), k: int = 8):
+    return {"query": q, "results": web_search(q, max_results=k)}
+
+
+@app.get("/fetch")
+async def fetch_api(url: str = FQuery(..., min_length=4)):
+    return fetch_url(url)

--- a/src/tools/web.py
+++ b/src/tools/web.py
@@ -1,0 +1,59 @@
+import httpx, re
+from duckduckgo_search import DDGS
+import trafilatura
+from readability import Document
+
+UA = "NeuralLocalBrowser/1.0"
+TIMEOUT = 20.0
+MAX_BYTES = 2_500_000
+MAX_TEXT = 120_000
+
+def web_search(query: str, max_results: int = 8):
+    with DDGS() as ddgs:
+        hits = ddgs.text(query, max_results=max_results, safesearch="moderate")
+        out = []
+        for h in hits or []:
+            out.append({
+                "title": h.get("title", "")[:200],
+                "url": h.get("href", ""),
+                "snippet": (h.get("body", "") or "")[:500],
+            })
+        return out
+
+def fetch_url(url: str) -> dict:
+    if not re.match(r"^https?://", url):
+        url = "https://" + url
+    headers = {"User-Agent": UA, "Accept": "*/*"}
+    with httpx.Client(timeout=TIMEOUT, headers=headers, follow_redirects=True) as client:
+        r = client.get(url)
+        r.raise_for_status()
+        content = r.content[:MAX_BYTES]
+        text = extract_text(url, content)
+        return {
+            "url": str(r.url),
+            "status": r.status_code,
+            "title": extract_title(content) or "",
+            "text": text[:MAX_TEXT],
+        }
+
+def extract_title(content: bytes) -> str | None:
+    try:
+        doc = Document(content)
+        return doc.short_title()
+    except Exception:
+        return None
+
+def extract_text(url: str, content: bytes) -> str:
+    try:
+        downloaded = trafilatura.load_html(content, url=url)
+        txt = trafilatura.extract(downloaded, include_formatting=False, include_images=False) or ""
+        if txt.strip():
+            return txt
+    except Exception:
+        pass
+    try:
+        doc = Document(content)
+        html = doc.summary()
+        return trafilatura.utils.clean_text(html) or ""
+    except Exception:
+        return ""


### PR DESCRIPTION
## Summary
- add web search and URL fetching utilities using DuckDuckGo and trafilatura
- allow chat API to include web results or specific pages and expose /search and /fetch endpoints
- document new internet-enabled usage examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76c1247508321b62418b413b3dab7