### PR TITLE
Add YouTube transcript and PDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ curl -s http://127.0.0.1:8000/chat \
 curl -s "http://127.0.0.1:8000/search?q=thorium%20reactors"
 curl -s "http://127.0.0.1:8000/fetch?url=https://arxiv.org/abs/2407.12345"
 
+The fetch endpoint automatically extracts text from PDFs and can pull transcripts from YouTube videos.
+
 ## Mode 2 — Tiny trainer
 Your original model.py stays. Run: python model.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ httpx==0.27.0
 duckduckgo-search==6.2.10
 trafilatura==1.12.2
 readability-lxml==0.8.1
+youtube-transcript-api==1.2.2
+pypdf==6.0.0


### PR DESCRIPTION
## Summary
- fetch_url now extracts YouTube video transcripts via `YouTubeTranscriptApi`
- Support reading text from PDF files when fetching URLs
- Document new fetch capabilities and update dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76d36c814832183f9c90489c714ca