### PR TITLE
Add network retry and fallback

### DIFF
--- a/src/tools/web.py
+++ b/src/tools/web.py
@@ -1,4 +1,4 @@
-import httpx, re
+import httpx, re, time
 from duckduckgo_search import DDGS
 import trafilatura
 from readability import Document
@@ -8,37 +8,61 @@ from io import BytesIO
 from pypdf import PdfReader
 
 UA = "NeuralLocalBrowser/1.0"
-TIMEOUT = 20.0
+# More aggressive connect timeout to fail fast on network issues while
+# allowing longer for reading large pages.
+TIMEOUT = httpx.Timeout(20.0, connect=5.0)
 MAX_BYTES = 2_500_000
 MAX_TEXT = 120_000
+MAX_RETRIES = 3
+RETRY_DELAY = 1.0
 
 def web_search(query: str, max_results: int = 8):
-    with DDGS() as ddgs:
-        hits = ddgs.text(query, max_results=max_results, safesearch="moderate")
-        out = []
-        for h in hits or []:
-            out.append({
-                "title": h.get("title", "")[:200],
-                "url": h.get("href", ""),
-                "snippet": (h.get("body", "") or "")[:500],
-            })
-        return out
+    """DuckDuckGo search with simple retry and graceful fallback."""
+    for attempt in range(MAX_RETRIES):
+        try:
+            with DDGS() as ddgs:
+                hits = ddgs.text(query, max_results=max_results, safesearch="moderate")
+                out = []
+                for h in hits or []:
+                    out.append({
+                        "title": h.get("title", "")[:200],
+                        "url": h.get("href", ""),
+                        "snippet": (h.get("body", "") or "")[:500],
+                    })
+                return out
+        except Exception:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAY)
+    return []
 
 def fetch_url(url: str) -> dict:
+    """Download a URL with retries and basic error handling."""
     if not re.match(r"^https?://", url):
         url = "https://" + url
     headers = {"User-Agent": UA, "Accept": "*/*"}
-    with httpx.Client(timeout=TIMEOUT, headers=headers, follow_redirects=True) as client:
-        r = client.get(url)
-        r.raise_for_status()
-        content = r.content[:MAX_BYTES]
-        text = extract_text(str(r.url), content)
-        return {
-            "url": str(r.url),
-            "status": r.status_code,
-            "title": extract_title(content) or "",
-            "text": text[:MAX_TEXT],
-        }
+    last_exc: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            with httpx.Client(timeout=TIMEOUT, headers=headers, follow_redirects=True) as client:
+                r = client.get(url)
+                r.raise_for_status()
+                content = r.content[:MAX_BYTES]
+                text = extract_text(str(r.url), content)
+                return {
+                    "url": str(r.url),
+                    "status": r.status_code,
+                    "title": extract_title(content) or "",
+                    "text": text[:MAX_TEXT],
+                }
+        except Exception as e:
+            last_exc = e
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAY)
+    # Fallback result when all retries failed
+    status = None
+    if isinstance(last_exc, httpx.HTTPStatusError) and last_exc.response is not None:
+        status = last_exc.response.status_code
+    return {"url": url, "status": status, "title": "", "text": ""}
 
 def extract_title(content: bytes) -> str | None:
     try:

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -1,0 +1,26 @@
+import httpx
+from unittest.mock import patch
+import sys
+import types
+
+# Provide dummy modules so tools.web can import without optional deps
+sys.modules.setdefault("duckduckgo_search", types.SimpleNamespace(DDGS=None))
+sys.modules.setdefault("trafilatura", types.SimpleNamespace(load_html=lambda *a, **k: "", extract=lambda *a, **k: "", utils=types.SimpleNamespace(clean_text=lambda x: x)))
+sys.modules.setdefault("readability", types.SimpleNamespace(Document=lambda *a, **k: types.SimpleNamespace(short_title=lambda: "", summary=lambda: "")))
+sys.modules.setdefault("youtube_transcript_api", types.SimpleNamespace(YouTubeTranscriptApi=types.SimpleNamespace(get_transcript=lambda *a, **k: [])))
+sys.modules.setdefault("pypdf", types.SimpleNamespace(PdfReader=lambda *a, **k: types.SimpleNamespace(pages=[])))
+
+from tools.web import fetch_url
+
+
+def test_fetch_url_fallback_on_error():
+    req = httpx.Request("GET", "https://example.com")
+
+    def boom(*args, **kwargs):
+        raise httpx.RequestError("boom", request=req)
+
+    with patch("httpx.Client.get", side_effect=boom):
+        result = fetch_url("https://example.com")
+
+    assert result["status"] is None
+    assert result["text"] == ""


### PR DESCRIPTION
## Summary
- add network retries and graceful fallbacks for web operations with tuned timeouts
- test network fetch fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77072a2f48321bcc700c7cea1cc61