### PR TITLE
Add basic summarization to chat memory

### DIFF
--- a/src/chat_server/memory.py
+++ b/src/chat_server/memory.py
@@ -7,15 +7,22 @@ from typing import Any, Dict, List
 
 
 class DiskMemory:
-    """Simple JSON-based memory storage on disk.
+    """Simple JSON-based memory storage on disk with basic summarization.
 
     Conversations are stored per identity in ``memory_dir``. Each file
     contains a list of message dictionaries with ``user`` and
-    ``assistant`` fields.
+    ``assistant`` fields.  When a conversation grows beyond
+    ``max_messages`` entries the older portion is condensed into a single
+    ``summary`` entry to keep memory files from growing without bound.
+    The summarisation is intentionally lightweight: older messages are
+    concatenated and truncated, preserving only the most recent
+    ``summary_keep`` interactions verbatim.
     """
 
-    def __init__(self, memory_dir: str) -> None:
+    def __init__(self, memory_dir: str, *, max_messages: int = 100, summary_keep: int = 20) -> None:
         self.memory_dir = memory_dir
+        self.max_messages = max_messages
+        self.summary_keep = summary_keep
         os.makedirs(self.memory_dir, exist_ok=True)
 
     def _path(self, identity: str) -> str:
@@ -29,7 +36,48 @@ class DiskMemory:
         return []
 
     def append(self, identity: str, message: Dict[str, Any]) -> None:
+        """Append ``message`` to ``identity``'s history and summarise if needed."""
+
         history = self.load(identity)
         history.append(message)
+
+        if len(history) > self.max_messages:
+            # First time the limit is exceeded: summarise everything except
+            # the most recent ``summary_keep`` interactions.
+            to_summarise = history[:-self.summary_keep]
+            recent = history[-self.summary_keep:]
+            summary_text = self._summarise(to_summarise)
+            history = [{"summary": summary_text}] + recent
+        elif history and "summary" in history[0] and len(history) > self.summary_keep + 1:
+            # Subsequent appends after a summary exists: fold the new older
+            # messages into the existing summary so that only the most
+            # recent ``summary_keep`` remain verbatim.
+            existing = history[0]["summary"]
+            to_summarise = history[1:-self.summary_keep]
+            if to_summarise:
+                summary_text = existing + "\n" + self._summarise(to_summarise)
+                history = [{"summary": summary_text}] + history[-self.summary_keep:]
+
         with open(self._path(identity), "w", encoding="utf-8") as f:
             json.dump(history, f, ensure_ascii=False, indent=2)
+
+    def _summarise(self, messages: List[Dict[str, Any]]) -> str:
+        """Create a lightweight summary string from ``messages``.
+
+        The summarisation strategy is deliberately simple: join user and
+        assistant turns line by line and truncate the result.  This keeps
+        dependencies minimal while still capturing the gist of older
+        conversation fragments.
+        """
+
+        lines: List[str] = []
+        for m in messages:
+            user = m.get("user")
+            if user:
+                lines.append(f"user: {user}")
+            assistant = m.get("assistant")
+            if assistant:
+                lines.append(f"assistant: {assistant}")
+        joined = "\n".join(lines)
+        # Limit summary size to avoid creating overly large entries.
+        return joined[:1000]

--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -1,0 +1,13 @@
+from chat_server.memory import DiskMemory
+
+def test_disk_memory_summarises(tmp_path):
+    mem = DiskMemory(str(tmp_path), max_messages=5, summary_keep=2)
+    identity = "id"
+    for i in range(7):
+        mem.append(identity, {"user": f"u{i}", "assistant": f"a{i}"})
+    history = mem.load(identity)
+    # Expect one summary entry plus the last two interactions
+    assert len(history) == 3
+    assert "summary" in history[0]
+    assert history[1]["user"] == "u5"
+    assert history[2]["assistant"] == "a6"


### PR DESCRIPTION
## Summary
- Condense long conversation histories by summarizing older turns and keeping only recent exchanges.
- Add unit test verifying the summarization behaviour of the disk-backed memory store.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b775b71f4c832193a2480b1dc9b627