### PR TITLE
feat: improve chat web ui

### DIFF
--- a/index/index.html
+++ b/index/index.html
@@ -9,8 +9,14 @@
   <div id="chat-container">
     <h1>Ember Chat</h1>
     <div id="chat-box"></div>
-    <input id="message" type="text" placeholder="Type a message" />
-    <button id="send">Send</button>
+    <div id="options">
+      <label><input type="checkbox" id="use-web" /> Enable web search</label>
+      <input id="web-query" type="text" placeholder="Custom web query (optional)" />
+    </div>
+    <div id="input-bar">
+      <input id="message" type="text" placeholder="Type a message" />
+      <button id="send">Send</button>
+    </div>
   </div>
   <script src="/assets/main.js"></script>
 </body>

--- a/index/main.js
+++ b/index/main.js
@@ -1,18 +1,39 @@
+const HISTORY_KEY = 'chat-history';
+let history = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
+
+function renderHistory() {
+  const box = document.getElementById('chat-box');
+  box.innerHTML = '';
+  history.forEach(item => {
+    box.innerHTML += `<div class="user">${item.user}</div>`;
+    box.innerHTML += `<div class="assistant">${item.assistant}</div>`;
+  });
+  box.scrollTop = box.scrollHeight;
+}
+
 async function sendMessage() {
   const input = document.getElementById('message');
   const msg = input.value.trim();
   if (!msg) return;
+  const useWeb = document.getElementById('use-web').checked;
+  const webQueryInput = document.getElementById('web-query');
+  const webQuery = webQueryInput.value.trim();
+  const payload = { message: msg };
+  if (useWeb) {
+    payload.use_web = true;
+    if (webQuery) payload.web_query = webQuery;
+  }
   const res = await fetch('/chat', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({message: msg}),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
   });
   const data = await res.json();
-  const box = document.getElementById('chat-box');
-  box.innerHTML += `<div class="user">${msg}</div>`;
-  box.innerHTML += `<div class="assistant">${data.reply}</div>`;
+  history.push({ user: msg, assistant: data.reply });
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  renderHistory();
   input.value = '';
-  box.scrollTop = box.scrollHeight;
+  webQueryInput.value = '';
 }
 
 document.getElementById('send').addEventListener('click', sendMessage);
@@ -22,3 +43,5 @@ document.getElementById('message').addEventListener('keypress', (e) => {
     sendMessage();
   }
 });
+
+renderHistory();

--- a/index/style.css
+++ b/index/style.css
@@ -17,17 +17,37 @@ body {
   padding: 10px;
   margin-bottom: 10px;
 }
+
 .user {
   text-align: right;
   color: #333;
 }
+
 .assistant {
   text-align: left;
   color: #0066cc;
 }
-#message {
-  width: calc(100% - 60px);
+
+#options {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
 }
+
+#options #web-query {
+  flex: 1;
+}
+
+#input-bar {
+  display: flex;
+  gap: 10px;
+}
+
+#input-bar #message {
+  flex: 1;
+}
+
 #send {
-  width: 50px;
+  width: 60px;
 }


### PR DESCRIPTION
## Summary
- add a web search toggle and optional query input to the chat interface
- persist and render message history on the client
- style layout for new options and input bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b77a40f21c832188b20e6461532105