### PR TITLE
Add web tool tests and benchmarking helper

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,36 @@
+"""Simple performance benchmark for the local LLM engine."""
+from __future__ import annotations
+
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+# Ensure src/ is on path for direct execution
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from llm.engine import LLMEngine
+
+
+def main() -> None:
+    """Run a single chat request and report time and memory usage."""
+    try:
+        engine = LLMEngine("config.yaml")
+    except Exception as e:
+        print(f"LLM initialization failed: {e}")
+        return
+
+    tracemalloc.start()
+    start = time.perf_counter()
+    reply = engine.chat("Benchmarking run", "Hello")
+    duration = time.perf_counter() - start
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    print(f"Reply: {reply}")
+    print(f"Time: {duration:.2f}s")
+    print(f"Peak memory: {peak / 1_000_000:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/web.py
+++ b/src/tools/web.py
@@ -6,6 +6,7 @@ from youtube_transcript_api import YouTubeTranscriptApi
 from urllib.parse import urlparse, parse_qs
 from io import BytesIO
 from pypdf import PdfReader
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +31,9 @@ ALLOWED_EXTENSIONS = set(_web_cfg.get("allowed_file_extensions") or [])
 # Always allow URLs without an explicit extension
 ALLOWED_EXTENSIONS.add("")
 
+@lru_cache(maxsize=32)
 def web_search(query: str, max_results: int = 8):
-    """DuckDuckGo search with simple retry and graceful fallback."""
+    """DuckDuckGo search with simple retry, caching and graceful fallback."""
     last_exc: Exception | None = None
     for attempt in range(MAX_RETRIES):
         try:

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -10,7 +10,7 @@ sys.modules.setdefault("readability", types.SimpleNamespace(Document=lambda *a, 
 sys.modules.setdefault("youtube_transcript_api", types.SimpleNamespace(YouTubeTranscriptApi=types.SimpleNamespace(get_transcript=lambda *a, **k: [])))
 sys.modules.setdefault("pypdf", types.SimpleNamespace(PdfReader=lambda *a, **k: types.SimpleNamespace(pages=[])))
 
-from tools.web import fetch_url
+from tools.web import fetch_url, web_search, extract_text
 
 
 def test_fetch_url_fallback_on_error():
@@ -24,3 +24,40 @@ def test_fetch_url_fallback_on_error():
 
     assert result["status"] is None
     assert result["text"] == ""
+
+
+def test_web_search_basic():
+    class DummyDDGS:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def text(self, query, max_results=8, safesearch="moderate"):
+            return [{"title": "Title", "href": "http://x", "body": "Snippet"}]
+
+    with patch("tools.web.DDGS", DummyDDGS):
+        results = web_search("test")
+
+    assert results == [{"title": "Title", "url": "http://x", "snippet": "Snippet"}]
+
+
+def test_extract_text_pdf():
+    pdf_bytes = b"%PDF-1.4\n..."
+
+    class DummyPage:
+        def __init__(self, text):
+            self._text = text
+
+        def extract_text(self):
+            return self._text
+
+    class DummyReader:
+        def __init__(self, buf):
+            self.pages = [DummyPage("first"), DummyPage("second")]
+
+    with patch("tools.web.PdfReader", DummyReader):
+        text = extract_text("http://example.com/doc.pdf", pdf_bytes)
+
+    assert "first" in text and "second" in text


### PR DESCRIPTION
## Summary
- add caching to `web_search` for faster repeat queries
- test `web_search` result handling and PDF text extraction
- provide `scripts/benchmark.py` for timing and memory usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77b23daa08321b81e787bcfa277d5