### PR TITLE
Auto-configure API base for web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ The fetch endpoint automatically extracts text from PDFs and can pull transcript
 
 Static files in `docs/` provide a lightweight chat client that can be hosted
 with GitHub Pages. Enable Pages for the repository and point it at the `docs`
-folder. The page includes a field to configure the API base URL (for example
-`http://localhost:8000`).
+folder. The page automatically populates the API base URL, defaulting to the
+current page's origin or to `http://localhost:8000` when served from GitHub
+Pages. A field remains available to override this value if needed.
 
 ### Security
 By default the server binds only to localhost. URL fetching is limited to

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,7 +1,15 @@
 const HISTORY_KEY = 'chat-history';
 const API_KEY = 'api-base';
 let history = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
-let apiBase = localStorage.getItem(API_KEY) || '';
+let apiBase = localStorage.getItem(API_KEY);
+if (!apiBase) {
+  if (["localhost", "127.0.0.1"].includes(window.location.hostname)) {
+    apiBase = window.location.origin;
+  } else {
+    apiBase = "http://localhost:8000";
+  }
+  localStorage.setItem(API_KEY, apiBase);
+}
 
 function renderHistory() {
   const box = document.getElementById('chat-box');

--- a/index/main.js
+++ b/index/main.js
@@ -1,7 +1,15 @@
 const HISTORY_KEY = 'chat-history';
 const API_KEY = 'api-base';
 let history = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]');
-let apiBase = localStorage.getItem(API_KEY) || '';
+let apiBase = localStorage.getItem(API_KEY);
+if (!apiBase) {
+  if (["localhost", "127.0.0.1"].includes(window.location.hostname)) {
+    apiBase = window.location.origin;
+  } else {
+    apiBase = "http://localhost:8000";
+  }
+  localStorage.setItem(API_KEY, apiBase);
+}
 
 function renderHistory() {
   const box = document.getElementById('chat-box');


### PR DESCRIPTION
## Summary
- Automatically detect API base URL for the lightweight chat client
- Default to the current page origin or localhost for GitHub Pages
- Document the new behavior in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7807494c48321bcb36e510445616a