### PR TITLE
Disable Jekyll for GitHub Pages docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The fetch endpoint automatically extracts text from PDFs and can pull transcript
 
 Static files in `docs/` provide a lightweight chat client that can be hosted
 with GitHub Pages. Enable Pages for the repository and point it at the `docs`
-folder. The page automatically populates the API base URL, using the current
-origin when accessed locally and otherwise pointing to `localhost:8000` on the
-same protocol (e.g., `https://localhost:8000` when served over HTTPS). A field
-remains available to override this value if needed.
+folder. A `.nojekyll` file is included so that GitHub Pages serves the static
+assets as-is without running them through Jekyll. The page automatically
+populates the API base URL, using the current origin when accessed locally and
+otherwise pointing to `localhost:8000` on the same protocol (e.g.,
+`https://localhost:8000` when served over HTTPS). A field remains available to
+override this value if needed.
 
 ### Security
 By default the server binds only to localhost. URL fetching is limited to


### PR DESCRIPTION
## Summary
- Add an empty `.nojekyll` marker in `docs/` so GitHub Pages serves static assets without Jekyll
- Document the `.nojekyll` setup in README's GitHub Pages section

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78363e9388321bdd501ac73bb2103