### PR TITLE
Add pretrained transformer support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ youtube-transcript-api==1.2.2
 pypdf==6.0.0
 tf-keras==2.19.0
 tensorflow==2.19.1
+torch
+transformers
+datasets


### PR DESCRIPTION
## Summary
- expand TransformerModel defaults to modern GPT-2 like dimensions and GELU activation
- add ability to load and fine-tune pretrained causal language models
- ensure tokenizers without pad tokens default to eos and update requirements with torch, transformers, datasets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b785d6b2408321aa74f284acc099e9