### PR TITLE
Expand index with three.js visualizer and rich layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,22 +6,78 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="chat-container">
-    <h1>Ember Chat</h1>
-    <div id="server">
-      <input id="api-base" type="text" placeholder="API base URL (e.g., http://localhost:8000)" />
-      <button id="save-api">Save</button>
-    </div>
-    <div id="chat-box"></div>
-    <div id="options">
-      <label><input type="checkbox" id="use-web" /> Enable web search</label>
-      <input id="web-query" type="text" placeholder="Custom web query (optional)" />
-    </div>
-    <div id="input-bar">
-      <input id="message" type="text" placeholder="Type a message" />
-      <button id="send">Send</button>
-    </div>
-  </div>
+  <header>
+    <nav>
+      <ul>
+        <li><a href="#intro">Home</a></li>
+        <li><a href="#visualizer">Visualizer</a></li>
+        <li><a href="#chat">Chat</a></li>
+        <li><a href="#about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section id="intro">
+      <h1>Ember Chat</h1>
+      <p>
+        Welcome to Ember Chat, a lightweight web client for talking to your AI models.
+        The interface below allows you to connect to a backend server, send messages,
+        and even augment responses with web search results. Scroll down to explore
+        a real-time 3D visualization rendered with <strong>three.js</strong> and
+        learn more about the project.
+      </p>
+    </section>
+
+    <section id="visualizer">
+      <h2>3D Visualizer</h2>
+      <div id="scene-container"></div>
+      <div id="scene-controls">
+        <label for="cube-color">Cube Color</label>
+        <input type="color" id="cube-color" value="#ff0000" />
+        <label for="rotation-speed">Rotation Speed</label>
+        <input type="range" id="rotation-speed" min="0" max="0.1" step="0.001" value="0.01" />
+        <button id="toggle-rotation">Pause Rotation</button>
+        <button id="toggle-wireframe">Toggle Wireframe</button>
+        <button id="reset-view">Reset View</button>
+      </div>
+    </section>
+
+    <section id="chat">
+      <div id="chat-container">
+        <h2>Chat</h2>
+        <div id="server">
+          <input id="api-base" type="text" placeholder="API base URL (e.g., http://localhost:8000)" />
+          <button id="save-api">Save</button>
+        </div>
+        <div id="chat-box"></div>
+        <div id="options">
+          <label><input type="checkbox" id="use-web" /> Enable web search</label>
+          <input id="web-query" type="text" placeholder="Custom web query (optional)" />
+        </div>
+        <div id="input-bar">
+          <input id="message" type="text" placeholder="Type a message" />
+          <button id="send">Send</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="about">
+      <h2>About</h2>
+      <p>
+        Ember Chat is an experiment in building approachable interfaces for complex AI models.
+        This demo showcases a simple conversational UI alongside a basic 3D scene to illustrate
+        how traditional web apps can blend with WebGL-powered visuals. Feel free to inspect
+        the code, modify it, and build your own experiments on top of it.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Ember Chat. All rights reserved.</p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/three@0.156.1/build/three.min.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,7 +1,31 @@
 body {
   font-family: Arial, sans-serif;
   background-color: #f9f9f9;
+  margin: 0;
 }
+
+header {
+  background: #222;
+  color: #fff;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 15px;
+  padding: 10px;
+  margin: 0;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+main section {
+  padding: 20px;
+}
+
 #chat-container {
   max-width: 600px;
   margin: 40px auto;
@@ -10,6 +34,7 @@ body {
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0,0,0,0.1);
 }
+
 #chat-box {
   height: 300px;
   overflow-y: auto;
@@ -60,4 +85,24 @@ body {
 
 #server input {
   flex: 1;
+}
+
+/* Three.js visualizer styles */
+#scene-container {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #ddd;
+  margin-bottom: 10px;
+}
+
+#scene-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 40px;
+}
+
+#scene-controls label {
+  margin-right: 5px;
 }

--- a/index/index.html
+++ b/index/index.html
@@ -3,25 +3,81 @@
 <head>
   <meta charset="UTF-8" />
   <title>Ember Chat</title>
-  <link rel="stylesheet" href="/assets/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="chat-container">
-    <h1>Ember Chat</h1>
-    <div id="server">
-      <input id="api-base" type="text" placeholder="API base URL (e.g., http://localhost:8000)" />
-      <button id="save-api">Save</button>
-    </div>
-    <div id="chat-box"></div>
-    <div id="options">
-      <label><input type="checkbox" id="use-web" /> Enable web search</label>
-      <input id="web-query" type="text" placeholder="Custom web query (optional)" />
-    </div>
-    <div id="input-bar">
-      <input id="message" type="text" placeholder="Type a message" />
-      <button id="send">Send</button>
-    </div>
-  </div>
-  <script src="/assets/main.js"></script>
+  <header>
+    <nav>
+      <ul>
+        <li><a href="#intro">Home</a></li>
+        <li><a href="#visualizer">Visualizer</a></li>
+        <li><a href="#chat">Chat</a></li>
+        <li><a href="#about">About</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section id="intro">
+      <h1>Ember Chat</h1>
+      <p>
+        Welcome to Ember Chat, a lightweight web client for talking to your AI models.
+        The interface below allows you to connect to a backend server, send messages,
+        and even augment responses with web search results. Scroll down to explore
+        a real-time 3D visualization rendered with <strong>three.js</strong> and
+        learn more about the project.
+      </p>
+    </section>
+
+    <section id="visualizer">
+      <h2>3D Visualizer</h2>
+      <div id="scene-container"></div>
+      <div id="scene-controls">
+        <label for="cube-color">Cube Color</label>
+        <input type="color" id="cube-color" value="#ff0000" />
+        <label for="rotation-speed">Rotation Speed</label>
+        <input type="range" id="rotation-speed" min="0" max="0.1" step="0.001" value="0.01" />
+        <button id="toggle-rotation">Pause Rotation</button>
+        <button id="toggle-wireframe">Toggle Wireframe</button>
+        <button id="reset-view">Reset View</button>
+      </div>
+    </section>
+
+    <section id="chat">
+      <div id="chat-container">
+        <h2>Chat</h2>
+        <div id="server">
+          <input id="api-base" type="text" placeholder="API base URL (e.g., http://localhost:8000)" />
+          <button id="save-api">Save</button>
+        </div>
+        <div id="chat-box"></div>
+        <div id="options">
+          <label><input type="checkbox" id="use-web" /> Enable web search</label>
+          <input id="web-query" type="text" placeholder="Custom web query (optional)" />
+        </div>
+        <div id="input-bar">
+          <input id="message" type="text" placeholder="Type a message" />
+          <button id="send">Send</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="about">
+      <h2>About</h2>
+      <p>
+        Ember Chat is an experiment in building approachable interfaces for complex AI models.
+        This demo showcases a simple conversational UI alongside a basic 3D scene to illustrate
+        how traditional web apps can blend with WebGL-powered visuals. Feel free to inspect
+        the code, modify it, and build your own experiments on top of it.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Ember Chat. All rights reserved.</p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/three@0.156.1/build/three.min.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/index/main.js
+++ b/index/main.js
@@ -65,3 +65,129 @@ document.getElementById('message').addEventListener('keypress', (e) => {
 });
 
 renderHistory();
+
+/* ------------------------------------------------------------------
+ * 3D Visualization using Three.js
+ * ------------------------------------------------------------------
+ */
+
+// Grab the container element that will hold our WebGL canvas.
+const sceneContainer = document.getElementById('scene-container');
+
+// Only attempt to set up the scene if the container exists on the page.
+if (sceneContainer) {
+  let scene, camera, renderer, cube;
+  let rotationSpeed = parseFloat(document.getElementById('rotation-speed').value);
+  let isRotating = true;
+
+  // Initialize Three.js scene, camera, renderer, and objects.
+  function initScene() {
+    scene = new THREE.Scene();
+    scene.background = new THREE.Color(0xf0f0f0);
+
+    const width = sceneContainer.clientWidth;
+    const height = sceneContainer.clientHeight;
+
+    camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    camera.position.set(2, 2, 5);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(width, height);
+    sceneContainer.appendChild(renderer.domElement);
+
+    // Primary cube geometry that users can manipulate.
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshStandardMaterial({ color: document.getElementById('cube-color').value });
+    cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    // Add a star field for visual interest.
+    createStarField();
+
+    // Lighting: a mix of ambient and directional light for realism.
+    const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+    scene.add(ambient);
+
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.set(5, 5, 5);
+    scene.add(directional);
+
+    // Kick off the animation loop.
+    animate();
+  }
+
+  // Create a field of randomly placed stars.
+  function createStarField() {
+    const starGeometry = new THREE.BufferGeometry();
+    const starCount = 500;
+    const positions = [];
+
+    for (let i = 0; i < starCount; i++) {
+      const x = THREE.MathUtils.randFloatSpread(200);
+      const y = THREE.MathUtils.randFloatSpread(200);
+      const z = THREE.MathUtils.randFloatSpread(200);
+      positions.push(x, y, z);
+    }
+
+    starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    const starMaterial = new THREE.PointsMaterial({ color: 0xffffff });
+    const stars = new THREE.Points(starGeometry, starMaterial);
+    scene.add(stars);
+  }
+
+  // Animation loop: rotate the cube and render the scene.
+  function animate() {
+    requestAnimationFrame(animate);
+
+    if (isRotating) {
+      cube.rotation.x += rotationSpeed;
+      cube.rotation.y += rotationSpeed;
+    }
+
+    renderer.render(scene, camera);
+  }
+
+  // Ensure the canvas and camera stay responsive on window resize.
+  function onWindowResize() {
+    const width = sceneContainer.clientWidth;
+    const height = sceneContainer.clientHeight;
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height);
+  }
+
+  // UI Controls for interacting with the visualization.
+  const colorInput = document.getElementById('cube-color');
+  const speedInput = document.getElementById('rotation-speed');
+  const toggleRotationBtn = document.getElementById('toggle-rotation');
+  const toggleWireframeBtn = document.getElementById('toggle-wireframe');
+  const resetViewBtn = document.getElementById('reset-view');
+
+  colorInput.addEventListener('input', () => {
+    cube.material.color.set(colorInput.value);
+  });
+
+  speedInput.addEventListener('input', () => {
+    rotationSpeed = parseFloat(speedInput.value);
+  });
+
+  toggleRotationBtn.addEventListener('click', () => {
+    isRotating = !isRotating;
+    toggleRotationBtn.textContent = isRotating ? 'Pause Rotation' : 'Resume Rotation';
+  });
+
+  toggleWireframeBtn.addEventListener('click', () => {
+    cube.material.wireframe = !cube.material.wireframe;
+  });
+
+  resetViewBtn.addEventListener('click', () => {
+    camera.position.set(2, 2, 5);
+    camera.lookAt(0, 0, 0);
+  });
+
+  window.addEventListener('resize', onWindowResize);
+
+  // Initialize everything when the script loads.
+  initScene();
+}

--- a/index/style.css
+++ b/index/style.css
@@ -1,7 +1,31 @@
 body {
   font-family: Arial, sans-serif;
   background-color: #f9f9f9;
+  margin: 0;
 }
+
+header {
+  background: #222;
+  color: #fff;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 15px;
+  padding: 10px;
+  margin: 0;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+main section {
+  padding: 20px;
+}
+
 #chat-container {
   max-width: 600px;
   margin: 40px auto;
@@ -10,6 +34,7 @@ body {
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0,0,0,0.1);
 }
+
 #chat-box {
   height: 300px;
   overflow-y: auto;
@@ -60,4 +85,24 @@ body {
 
 #server input {
   flex: 1;
+}
+
+/* Three.js visualizer styles */
+#scene-container {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #ddd;
+  margin-bottom: 10px;
+}
+
+#scene-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 40px;
+}
+
+#scene-controls label {
+  margin-right: 5px;
 }


### PR DESCRIPTION
## Summary
- Rework index and docs HTML with navigation, about, and 3D visualizer sections
- Sync docs assets and use relative paths so GitHub Pages loads the enhanced layout
- Style layout and visualizer elements for a polished experience

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b786d571b88321ab37fbbdcaaaaa7a